### PR TITLE
Increase space between icon and error

### DIFF
--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -39,10 +39,10 @@ create_core() {
         echo "✅  Core '$name' created"
     elif [ "$status" -eq 500 ]; then
         error_core=$(echo "$response" | yqd '.error.msg')
-        echo "ℹ️ $error_core"
+        echo "ℹ️  $error_core"
     else
         error_message=$(echo "$response" | yqd '.error.msg')
-        echo "❌ $error_message"
+        echo "❌  $error_message"
         exit 1
     fi
 }


### PR DESCRIPTION
The output icon has no space to the error message 'Core with name [...] exists'

![image](https://github.com/ddev/ddev-typo3-solr/assets/14198734/d928a972-fef3-4c5d-a4d5-84540f4c7ced)

This improves the output's readability.

![image](https://github.com/ddev/ddev-typo3-solr/assets/14198734/5e865724-d2be-474d-916c-2e832d300518)
