### PR TITLE
[TASK] Fix example property "configsets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configuration example for TYPO3 in `.ddev/typo3-solr/config.yaml`:
 
 ```yaml
 config: 'vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/solr.xml'
-configset:
+configsets:
     - name: "ext_solr_12_0_0"
       path: "vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/configsets/ext_solr_12_0_0"
       cores:


### PR DESCRIPTION
## The Issue

The example config uses `configset` which is not correct.

## How This PR Solves The Issue

Now the examples uses the correct value names `configsets`


