### PR TITLE
[TASK] Set permissions on copied files

### DIFF
--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -93,6 +93,7 @@ apply)
     docker exec -i ddev-"$DDEV_SITENAME"-typo3-solr mkdir -p /var/solr/data/configsets/
     echo "🐳 Copy $(basename "$config") to container"
     docker cp "$config" ddev-"$DDEV_SITENAME"-typo3-solr:/var/solr/data/ 1>/dev/null
+    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr /var/solr/data/
     docker restart ddev-"$DDEV_SITENAME"-typo3-solr 1>/dev/null
     wait_for_solr
 
@@ -108,6 +109,7 @@ apply)
 
         echo "🐳 Copy configset '$configset_name' to container"
         docker cp "$configset_path/." "ddev-$DDEV_SITENAME-typo3-solr:/var/solr/data/configsets/$configset_name" 1>/dev/null
+        docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr "/var/solr/data/configsets/$configset_name"
 
         # Create solr cores if needed
         IFS=$'\n' cores_array=($(echo "$configset" | yqd -o=j -I=0 '.cores.[]'))


### PR DESCRIPTION
## The Issue

Permissions are not properly set after files being copied to the container

## How This PR Solves The Issue

Settings permissions to the solr data folder for newly copied files to 'solr'

## Manual Testing Instructions

## Related Issue Link(s)

Fixes #7

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

