### PR TITLE
feat: add v1.24.3 constraint, add SOLR_BASE_IMAGE env

### DIFF
--- a/commands/typo3-solr/solr
+++ b/commands/typo3-solr/solr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 
 ## Description: Manage parts of solr

--- a/docker-compose.typo3-solr.yaml
+++ b/docker-compose.typo3-solr.yaml
@@ -3,13 +3,13 @@ services:
   typo3-solr:
     container_name: ddev-${DDEV_SITENAME}-typo3-solr
     hostname: ${DDEV_SITENAME}-typo3-solr
-    image: solr:9.8
+    image: ${SOLR_BASE_IMAGE:-solr:9.8}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=8983
+      - HTTP_EXPOSE=8983:8983
       - HTTPS_EXPOSE=8984:8983
       # For setup steps see https://docs.typo3.org/p/apache-solr-for-typo3/solr/main/en-us/Solr/ConfigurationStructures.html#setup-steps
       - SOLR_ENABLE_REMOTE_STREAMING=true
@@ -19,8 +19,6 @@ services:
       - "typo3-solr:/var/solr/"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
-  web:
-    links:
-      - typo3-solr
+
 volumes:
   typo3-solr:

--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,3 @@
-# Details about the install.yaml file are at https://ddev.readthedocs.io/en/latest/users/extend/additional-services/#sections-and-features-of-ddev-get-add-on-installyaml
 name: typo3-solr
 
 project_files:
@@ -6,3 +5,5 @@ project_files:
   - typo3-solr/config.yaml
   - commands/host/solrctl
   - commands/typo3-solr/solr
+
+ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

Applying changes from upstream.

## How This PR Solves The Issue

- Adds `SOLR_BASE_IMAGE` (docs will be updated in the next PR)
- Removes web links (not needed with newer docker-compose)
- Specify `HTTP_EXPOSE=8983:8983` port explicitly (it changes nothing)
- Uses `#!/usr/bin/env bash` everywhere instead of `#!/bin/bash`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-typo3-solr/tarball/20250424_stasadev_constraint
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
