### PR TITLE
[TASK] Upgrade to solr core 9.10

### DIFF
--- a/docker-compose.typo3-solr.yaml
+++ b/docker-compose.typo3-solr.yaml
@@ -3,7 +3,7 @@ services:
   typo3-solr:
     container_name: ddev-${DDEV_SITENAME}-typo3-solr
     hostname: ${DDEV_SITENAME}-typo3-solr
-    image: ${SOLR_BASE_IMAGE:-solr:9.8}
+    image: ${SOLR_BASE_IMAGE:-solr:9.10}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT

--- a/tests/testdata/configset/conf/arabic/schema.xml
+++ b/tests/testdata/configset/conf/arabic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/armenian/schema.xml
+++ b/tests/testdata/configset/conf/armenian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/basque/schema.xml
+++ b/tests/testdata/configset/conf/basque/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/brazilian_portuguese/schema.xml
+++ b/tests/testdata/configset/conf/brazilian_portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/bulgarian/schema.xml
+++ b/tests/testdata/configset/conf/bulgarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/burmese/schema.xml
+++ b/tests/testdata/configset/conf/burmese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/catalan/schema.xml
+++ b/tests/testdata/configset/conf/catalan/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/chinese/schema.xml
+++ b/tests/testdata/configset/conf/chinese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/czech/schema.xml
+++ b/tests/testdata/configset/conf/czech/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/danish/schema.xml
+++ b/tests/testdata/configset/conf/danish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/dutch/schema.xml
+++ b/tests/testdata/configset/conf/dutch/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/english/schema.xml
+++ b/tests/testdata/configset/conf/english/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/finnish/schema.xml
+++ b/tests/testdata/configset/conf/finnish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/french/schema.xml
+++ b/tests/testdata/configset/conf/french/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/galician/schema.xml
+++ b/tests/testdata/configset/conf/galician/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/generic/schema.xml
+++ b/tests/testdata/configset/conf/generic/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/german/schema.xml
+++ b/tests/testdata/configset/conf/german/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/greek/schema.xml
+++ b/tests/testdata/configset/conf/greek/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/hindi/schema.xml
+++ b/tests/testdata/configset/conf/hindi/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/hungarian/schema.xml
+++ b/tests/testdata/configset/conf/hungarian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/indonesian/schema.xml
+++ b/tests/testdata/configset/conf/indonesian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/irish/schema.xml
+++ b/tests/testdata/configset/conf/irish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/italian/schema.xml
+++ b/tests/testdata/configset/conf/italian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/japanese/schema.xml
+++ b/tests/testdata/configset/conf/japanese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/khmer/schema.xml
+++ b/tests/testdata/configset/conf/khmer/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/korean/schema.xml
+++ b/tests/testdata/configset/conf/korean/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/lao/schema.xml
+++ b/tests/testdata/configset/conf/lao/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/latvia/schema.xml
+++ b/tests/testdata/configset/conf/latvia/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/norwegian/schema.xml
+++ b/tests/testdata/configset/conf/norwegian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/persian/schema.xml
+++ b/tests/testdata/configset/conf/persian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/polish/schema.xml
+++ b/tests/testdata/configset/conf/polish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/portuguese/schema.xml
+++ b/tests/testdata/configset/conf/portuguese/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/romanian/schema.xml
+++ b/tests/testdata/configset/conf/romanian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/russian/schema.xml
+++ b/tests/testdata/configset/conf/russian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/serbian/schema.xml
+++ b/tests/testdata/configset/conf/serbian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/solrconfig.xml
+++ b/tests/testdata/configset/conf/solrconfig.xml
@@ -1,4 +1,4 @@
-<config name="tx_solr-13-0-0--20240513">
+<config name="tx_solr-13-1-0--20260128">
 
 	<luceneMatchVersion>9.3.0</luceneMatchVersion>
 

--- a/tests/testdata/configset/conf/spanish/schema.xml
+++ b/tests/testdata/configset/conf/spanish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/swedish/schema.xml
+++ b/tests/testdata/configset/conf/swedish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/thai/schema.xml
+++ b/tests/testdata/configset/conf/thai/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/turkish/schema.xml
+++ b/tests/testdata/configset/conf/turkish/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/tests/testdata/configset/conf/ukrainian/schema.xml
+++ b/tests/testdata/configset/conf/ukrainian/schema.xml
@@ -10,7 +10,7 @@
 	status report - tx_solr_report_SchemaStatus - checking against this
 	name property, that status check must be updated as well.
 -->
-<schema name="tx_solr-13-0-0--20240513" version="1.6">
+<schema name="tx_solr-13-1-0--20260128" version="1.6">
 	<!-- attribute "name" is the name of this schema and is only used for display purposes.
 		Applications should change this to reflect the nature of the search collection.
 		version="1.4" is Solr's version number for the schema syntax and semantics.  It should

--- a/typo3-solr/config.yaml
+++ b/typo3-solr/config.yaml
@@ -3,8 +3,8 @@
 config: "vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/solr.xml"
 typo3lib: "vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/typo3lib"
 configsets:
-  - name: "ext_solr_13_0_0"
-    path: "vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/configsets/ext_solr_13_0_0"
+  - name: "ext_solr_13_1_0"
+    path: "vendor/apache-solr-for-typo3/solr/Resources/Private/Solr/configsets/ext_solr_13_1_0"
     cores:
       - name: "core_en"
         schema: "english/schema.xml"


### PR DESCRIPTION
Upgraded to solr core version 9.10
Updated test data & configsets name

Related: #24 

## How This PR Solves The Issue

The TYPO3 Solr Extension upgraded to Apache Solr 9.10 due to security fixes, according to
- CVE-2025-54988
- CVE-2026-22444
- CVE-2026-22022

This PR upgrades to this Solr Core version and will solve the problem when trying to create a core in ddev.
Will solve the mentioned issue #24 as well as #23 


## Manual Testing Instructions

Install the addon using
```bash
ddev add-on get <addon-name>
ddev restart
ddev solrctl apply
```

