### PR TITLE
[TASK] Split script and run most parts in the web container

### DIFF
--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -31,12 +31,12 @@ apply)
     echo "Apply config $YAML_FILE"
 
     # Make Solr volume writable for web container, then copy files
-    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chmod -R 777 /var/solr/
+    ddev exec -s typo3-solr -u root chmod -R 777 /var/solr/
     ddev solrctl-worker copy-config "$YAML_FILE"
 
     # Restore file ownership for Solr
-    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr /var/solr/
-    docker restart ddev-"$DDEV_SITENAME"-typo3-solr 1>/dev/null
+    ddev exec -s typo3-solr -u root chown -R solr:solr /var/solr/
+    ddev utility rebuild -s typo3-solr --cache 1>/dev/null
     wait_for_solr
 
     # Create cores via Solr API
@@ -45,10 +45,10 @@ apply)
 
 wipe)
     # Make Solr volume writable, then unload cores and delete files via web container
-    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chmod -R 777 /var/solr/
+    ddev exec -s typo3-solr -u root chmod -R 777 /var/solr/
     ddev solrctl-worker wipe
 
-    docker restart ddev-"$DDEV_SITENAME"-typo3-solr 1>/dev/null
+    ddev utility rebuild -s typo3-solr --cache 1>/dev/null
     wait_for_solr
     ;;
 

--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -11,56 +11,6 @@ wait_for_solr() {
     ddev exec -s typo3-solr wait-for-solr.sh --wait-seconds 1 1>/dev/null
 }
 
-create_core() {
-    name="${1}"
-    configset="${2}"
-    schema="${3}"
-    if [ "$configset" = "" ]; then
-        echo "❌ Please define a configset!"
-        exit 1
-    fi
-    # Schema
-    schema_param=""
-    if [ ! "$schema" = "" ]; then
-        schema_param="&schema=$schema"
-    fi
-    api_url="http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=CREATE&name=$name&configSet=$configset&dataDir=./$schema_param"
-    response=$(ddev exec -s typo3-solr "curl -s '$api_url'")
-    response_code=$?
-    status=$(echo "$response" | ddev exec "yq '.responseHeader.status'")
-
-    if [ "$response_code" -gt 0 ]; then
-        echo "❌ Failed to call solr API on $api_url"
-        exit 1
-    fi
-
-    if [ "$status" = "0" ]; then
-        echo "✅ Core '$name' created"
-    elif [ "$status" = "500" ]; then
-        error_core=$(echo "$response" | ddev exec "yq '.error.msg'")
-        echo "ℹ️ $error_core"
-    else
-        error_message=$(echo "$response" | ddev exec "yq '.error.msg'")
-        echo "❌ $error_message"
-        exit 1
-    fi
-}
-
-delete_core() {
-    api_delete_url="http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=UNLOAD&core=$name&deleteIndex=true"
-    response=$(ddev exec -s typo3-solr "curl -s -X POST -H 'Content-type: application/json' '$api_delete_url'")
-    response_code=$?
-    status=$(echo "$response" | ddev exec "yq '.responseHeader.status'")
-
-    if [ "$status" -eq 0 ]; then
-        docker exec -u 0 -i ddev-"$DDEV_SITENAME"-typo3-solr rm -Rf /var/solr/data/"$name"
-        echo "🗑️Deleted core '$name' "
-    else
-        error_message=$(echo "$response" | ddev exec "yq '.error.msg'")
-        echo "ℹ️ Core '$name' - $error_message"
-    fi
-}
-
 # Start the project if not already running, so we can interact with solr
 ddev_status=$(ddev describe -j | ddev exec "yq -p=json eval '.raw.status'")
 if [ "$ddev_status" = "stopped" ]; then
@@ -80,106 +30,30 @@ apply)
 
     echo "Apply config $YAML_FILE"
 
-    YAML=$(cat "$YAML_FILE")
-    config="$DDEV_APPROOT/$(echo "$YAML" | ddev exec "yq eval '.config'")"
+    # Make Solr volume writable for web container, then copy files
+    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chmod -R 777 /var/solr/
+    ddev solrctl-worker copy-config "$YAML_FILE"
 
-    if [ ! -f "$config" ]; then
-        echo "Solr config file $config does not exist."
-        exit 1
-    fi
-
-    typo3lib="$DDEV_APPROOT/$(echo "$YAML" | ddev exec "yq eval '.typo3lib'")"
-    if [ ! -d "$typo3lib" ]; then
-        echo "The typo3lib folder $typo3lib does not exist."
-        exit 1
-    fi
-
-    # Copy files to the typo3-solr volume
-    docker exec -i ddev-"$DDEV_SITENAME"-typo3-solr mkdir -p /var/solr/data/configsets/
-    echo "🐳 Copy $(basename "$config") to container"
-    docker cp "$config" ddev-"$DDEV_SITENAME"-typo3-solr:/var/solr/data/ 1>/dev/null
-
-    echo "🐳 Copy typo3lib to container"
-    docker cp "$typo3lib" ddev-"$DDEV_SITENAME"-typo3-solr:/var/solr/data/ 1>/dev/null
-
-    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr /var/solr/data/
+    # Restore file ownership for Solr
+    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr /var/solr/
     docker restart ddev-"$DDEV_SITENAME"-typo3-solr 1>/dev/null
     wait_for_solr
 
-    api_url="http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS"
-    response=$(ddev exec -s typo3-solr "curl -s '$api_url'")
-    response_code=$?
-    existing_cores=$(echo "$response" | ddev exec "yq -r '.status | keys | .[]'")
-
-    if [ "$response_code" -gt 0 ]; then
-        echo "❌ Failed to call solr API on $api_url"
-        exit 1
-    fi
-
-    mapfile -t configsets < <(echo "$YAML" | ddev exec "yq -o=j -I=0 '.configsets.[]'")
-    for configset in "${configsets[@]}"; do
-        configset_name=$(echo "$configset" | ddev exec "yq '.name // \"\"' -")
-        configset_path="$DDEV_APPROOT/$(echo "$configset" | ddev exec "yq '.path // \"\"' -")"
-
-        if [ ! -d "$configset_path" ]; then
-            echo -e "Solr configset '$configset_name' does not exist."
-            exit 1
-        fi
-
-        echo "🐳 Copy configset '$configset_name' to container"
-        docker cp "$configset_path/." "ddev-$DDEV_SITENAME-typo3-solr:/var/solr/data/configsets/$configset_name" 1>/dev/null
-        docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chown -R solr:solr "/var/solr/data/configsets/$configset_name"
-
-        # Create solr cores if needed
-        mapfile -t cores_array < <(echo "$configset" | ddev exec "yq -o=j -I=0 '.cores.[]'")
-        for core in "${cores_array[@]}"; do
-            name=$(echo "$core" | ddev exec "yq '.name // \"\"' -")
-            schema=$(echo "$core" | ddev exec "yq '.schema // \"\"' -")
-
-            if [[ "${existing_cores[*]}" =~ (^|[[:space:]])"$name"($|[[:space:]]) ]]; then
-                echo "ℹ️ Core with name '$name' already exists."
-            else
-                create_core "$name" "$configset_name" "$schema"
-            fi
-        done
-    done
+    # Create cores via Solr API
+    ddev solrctl-worker create-cores "$YAML_FILE"
     ;;
 
 wipe)
-    api_url="http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS&wt=json"
-    response=$(ddev exec -s typo3-solr bin/solr api --solr-url "$api_url")
-    response_code=$?
+    # Make Solr volume writable, then unload cores and delete files via web container
+    docker exec -i -u root ddev-"$DDEV_SITENAME"-typo3-solr chmod -R 777 /var/solr/
+    ddev solrctl-worker wipe
 
-    if [ "$response_code" -gt 0 ]; then
-        echo "❌ Failed to call solr API on $api_url"
-    else
-        mapfile -t cores_array < <(echo "$response" | ddev exec "yq -o=j -I=0 '.status.[] // 0'")
-        if [ "$(echo -n "${cores_array[@]}")" != "0" ]; then
-            for core in "${cores_array[@]}"; do
-                name=$(echo "$core" | ddev exec "yq '.name // \"\"' -")
-
-                delete_core "$name"
-            done
-        fi
-    fi
-
-    # Delete all files in the
-    echo "🗑️Delete all configsets and solr.xml configuration"
-    docker exec -u 0 -i ddev-"$DDEV_SITENAME"-typo3-solr rm -Rf /var/solr/data/configsets /var/solr/data/solr.xml
     docker restart ddev-"$DDEV_SITENAME"-typo3-solr 1>/dev/null
-
     wait_for_solr
     ;;
 
 list)
-    api_url="http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS"
-    response=$(ddev exec -s typo3-solr "curl -s '$api_url'")
-    mapfile -t cores < <(echo "$response" | ddev exec "yq '.status | keys[]'")
-
-    echo "Found ${#cores[@]} cores"
-    for core in "${cores[@]}"; do
-        echo " *" "$core"
-    done
+    ddev solrctl-worker list
     ;;
 
 --help | *)

--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -7,10 +7,6 @@
 CMD=$1
 YAML_FILE=".ddev/typo3-solr/config.yaml"
 
-wait_for_solr() {
-    ddev exec -s typo3-solr wait-for-solr.sh --wait-seconds 1 1>/dev/null
-}
-
 # Start the project if not already running, so we can interact with solr
 ddev_status=$(ddev describe -j | ddev exec "yq -p=json eval '.raw.status'")
 if [ "$ddev_status" = "stopped" ]; then
@@ -37,7 +33,6 @@ apply)
     # Restore file ownership for Solr
     ddev exec -s typo3-solr -u root chown -R solr:solr /var/solr/
     ddev utility rebuild -s typo3-solr --cache 1>/dev/null
-    wait_for_solr
 
     # Create cores via Solr API
     ddev solrctl-worker create-cores "$YAML_FILE"
@@ -49,7 +44,6 @@ wipe)
     ddev solrctl-worker wipe
 
     ddev utility rebuild -s typo3-solr --cache 1>/dev/null
-    wait_for_solr
     ;;
 
 list)

--- a/commands/web/solrctl-worker
+++ b/commands/web/solrctl-worker
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#ddev-generated
+## Description: Worker for solrctl - runs inside web container
+## Usage: solrctl-worker [copy-config|create-cores|wipe|list] [config-path]
+## Example: "ddev solrctl-worker copy-config .ddev/typo3-solr/config.yaml"
+## ExecRaw: true
+
+set -euo pipefail
+
+SOLR_HOST="typo3-solr"
+SOLR_PORT="${SOLR_PORT:-8983}"
+SOLR_API="http://${SOLR_HOST}:${SOLR_PORT}/solr"
+SOLR_DATA="/mnt/typo3-solr/data"
+
+resolve_path() {
+    local path="$1"
+    if [[ "$path" = /* ]]; then
+        echo "$path"
+    else
+        echo "/var/www/html/$path"
+    fi
+}
+
+cmd_copy_config() {
+    local yaml_file="$1"
+    yaml_file=$(resolve_path "$yaml_file")
+
+    if [ ! -f "$yaml_file" ]; then
+        echo "Add-on config file $yaml_file does not exist."
+        exit 1
+    fi
+
+    local config_rel
+    config_rel=$(yq eval '.config' "$yaml_file")
+    local config="/var/www/html/$config_rel"
+
+    if [ ! -f "$config" ]; then
+        echo "Solr config file $config does not exist."
+        exit 1
+    fi
+
+    local typo3lib_rel
+    typo3lib_rel=$(yq eval '.typo3lib' "$yaml_file")
+    local typo3lib="/var/www/html/$typo3lib_rel"
+
+    if [ ! -d "$typo3lib" ]; then
+        echo "The typo3lib folder $typo3lib does not exist."
+        exit 1
+    fi
+
+    # Create directory structure
+    mkdir -p "${SOLR_DATA}/configsets/"
+
+    # Copy solr.xml
+    echo "🐳 Copy $(basename "$config") to container"
+    cp "$config" "${SOLR_DATA}/"
+
+    # Copy typo3lib
+    echo "🐳 Copy typo3lib to container"
+    cp -r "$typo3lib" "${SOLR_DATA}/"
+
+    # Copy each configset
+    local configset_count
+    configset_count=$(yq eval '.configsets | length' "$yaml_file")
+
+    for ((i = 0; i < configset_count; i++)); do
+        local configset_name
+        configset_name=$(yq eval ".configsets[$i].name // \"\"" "$yaml_file")
+        local configset_path_rel
+        configset_path_rel=$(yq eval ".configsets[$i].path // \"\"" "$yaml_file")
+        local configset_path="/var/www/html/$configset_path_rel"
+
+        if [ ! -d "$configset_path" ]; then
+            echo "Solr configset '$configset_name' does not exist."
+            exit 1
+        fi
+
+        echo "🐳 Copy configset '$configset_name' to container"
+        mkdir -p "${SOLR_DATA}/configsets/${configset_name}"
+        cp -r "${configset_path}/." "${SOLR_DATA}/configsets/${configset_name}/"
+    done
+}
+
+cmd_create_cores() {
+    local yaml_file="$1"
+    yaml_file=$(resolve_path "$yaml_file")
+
+    if [ ! -f "$yaml_file" ]; then
+        echo "Add-on config file $yaml_file does not exist."
+        exit 1
+    fi
+
+    # Get existing cores
+    local response
+    response=$(curl -s "${SOLR_API}/admin/cores?action=STATUS")
+    local response_code=$?
+
+    if [ "$response_code" -gt 0 ]; then
+        echo "❌ Failed to call solr API"
+        exit 1
+    fi
+
+    local existing_cores
+    existing_cores=$(echo "$response" | yq -r '.status | keys | .[]')
+
+    local configset_count
+    configset_count=$(yq eval '.configsets | length' "$yaml_file")
+
+    for ((i = 0; i < configset_count; i++)); do
+        local configset_name
+        configset_name=$(yq eval ".configsets[$i].name // \"\"" "$yaml_file")
+
+        local core_count
+        core_count=$(yq eval ".configsets[$i].cores | length" "$yaml_file")
+
+        for ((j = 0; j < core_count; j++)); do
+            local name
+            name=$(yq eval ".configsets[$i].cores[$j].name // \"\"" "$yaml_file")
+            local schema
+            schema=$(yq eval ".configsets[$i].cores[$j].schema // \"\"" "$yaml_file")
+
+            # Check if core already exists
+            if echo "$existing_cores" | grep -qx "$name"; then
+                echo "ℹ️ Core with name '$name' already exists."
+                continue
+            fi
+
+            # Build API URL
+            local schema_param=""
+            if [ -n "$schema" ]; then
+                schema_param="&schema=$schema"
+            fi
+
+            local api_url="${SOLR_API}/admin/cores?action=CREATE&name=$name&configSet=$configset_name&dataDir=./${schema_param}"
+            local core_response
+            core_response=$(curl -s "$api_url")
+            local core_response_code=$?
+
+            if [ "$core_response_code" -gt 0 ]; then
+                echo "❌ Failed to call solr API on $api_url"
+                exit 1
+            fi
+
+            local status
+            status=$(echo "$core_response" | yq '.responseHeader.status')
+
+            if [ "$status" = "0" ]; then
+                echo "✅ Core '$name' created"
+            elif [ "$status" = "500" ]; then
+                local error_core
+                error_core=$(echo "$core_response" | yq '.error.msg')
+                echo "ℹ️ $error_core"
+            else
+                local error_message
+                error_message=$(echo "$core_response" | yq '.error.msg')
+                echo "❌ $error_message"
+                exit 1
+            fi
+        done
+    done
+}
+
+cmd_wipe() {
+    local response
+    response=$(curl -s "${SOLR_API}/admin/cores?action=STATUS&wt=json")
+    local response_code=$?
+
+    if [ "$response_code" -gt 0 ]; then
+        echo "❌ Failed to call solr API"
+    else
+        local core_names
+        core_names=$(echo "$response" | yq -r '.status | keys | .[]')
+
+        if [ -n "$core_names" ]; then
+            while IFS= read -r name; do
+                local api_delete_url="${SOLR_API}/admin/cores?action=UNLOAD&core=$name&deleteIndex=true"
+                local del_response
+                del_response=$(curl -s -X POST -H 'Content-type: application/json' "$api_delete_url")
+                local status
+                status=$(echo "$del_response" | yq '.responseHeader.status')
+
+                if [ "$status" -eq 0 ]; then
+                    rm -rf "${SOLR_DATA:?}/${name}"
+                    echo "🗑️Deleted core '$name' "
+                else
+                    local error_message
+                    error_message=$(echo "$del_response" | yq '.error.msg')
+                    echo "ℹ️ Core '$name' - $error_message"
+                fi
+            done <<< "$core_names"
+        fi
+    fi
+
+    # Delete all configsets and solr.xml
+    echo "🗑️Delete all configsets and solr.xml configuration"
+    rm -rf "${SOLR_DATA}/configsets" "${SOLR_DATA}/solr.xml"
+}
+
+cmd_list() {
+    local response
+    response=$(curl -s "${SOLR_API}/admin/cores?action=STATUS")
+
+    local core_names
+    core_names=$(echo "$response" | yq '.status | keys[]')
+
+    local count=0
+    if [ -n "$core_names" ]; then
+        count=$(echo "$core_names" | wc -l | tr -d ' ')
+    fi
+
+    echo "Found $count cores"
+    if [ -n "$core_names" ]; then
+        while IFS= read -r core; do
+            echo " *" "$core"
+        done <<< "$core_names"
+    fi
+}
+
+CMD="${1:-}"
+shift || true
+
+case "$CMD" in
+    copy-config)
+        if [ -z "${1:-}" ]; then
+            echo "Usage: solrctl-worker copy-config <yaml-file>"
+            exit 1
+        fi
+        cmd_copy_config "$1"
+        ;;
+    create-cores)
+        if [ -z "${1:-}" ]; then
+            echo "Usage: solrctl-worker create-cores <yaml-file>"
+            exit 1
+        fi
+        cmd_create_cores "$1"
+        ;;
+    wipe)
+        cmd_wipe
+        ;;
+    list)
+        cmd_list
+        ;;
+    *)
+        echo "Usage: solrctl-worker [copy-config|create-cores|wipe|list] [config-path]"
+        exit 1
+        ;;
+esac

--- a/commands/web/solrctl-worker
+++ b/commands/web/solrctl-worker
@@ -146,15 +146,15 @@ cmd_create_cores() {
 
             if [ "$status" = "0" ]; then
                 echo "✅ Core '$name' created"
-            elif [ "$status" = "500" ]; then
-                local error_core
-                error_core=$(echo "$core_response" | yq '.error.msg')
-                echo "ℹ️ $error_core"
             else
                 local error_message
                 error_message=$(echo "$core_response" | yq '.error.msg')
-                echo "❌ $error_message"
-                exit 1
+                if [[ "$error_message" == *"already defined"* || "$error_message" == *"already exists"* ]]; then
+                    echo "ℹ️ Core with name '$name' already exists."
+                else
+                    echo "❌ $error_message"
+                    exit 1
+                fi
             fi
         done
     done

--- a/docker-compose.typo3-solr.yaml
+++ b/docker-compose.typo3-solr.yaml
@@ -20,5 +20,9 @@ services:
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
 
+  web:
+    volumes:
+      - "typo3-solr:/mnt/typo3-solr"
+
 volumes:
   typo3-solr:

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ project_files:
   - docker-compose.typo3-solr.yaml
   - typo3-solr/config.yaml
   - commands/host/solrctl
+  - commands/web/solrctl-worker
   - commands/typo3-solr/solr
 
 ddev_version_constraint: '>= v1.24.3'

--- a/install.yaml
+++ b/install.yaml
@@ -7,4 +7,4 @@ project_files:
   - commands/web/solrctl-worker
   - commands/typo3-solr/solr
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -59,6 +59,12 @@ health_checks() {
   assert_output --partial "* core_de"
   assert_output --partial "* core_en"
 
+  echo "Apply configuration with existing cores, do not fail on existing" >&3
+  run ddev solrctl apply tests/testdata/config.yaml
+  assert_success
+  assert_output --partial "Core with name 'core_de' already exists"
+  assert_output --partial "Core with name 'core_en' already exists"
+
   echo "Delete/wipe configuration" >&3
   run ddev solrctl wipe
   assert_success


### PR DESCRIPTION
## The Issue

- #26
- https://github.com/ddev/ddev-typo3-solr/pull/22#issue-3821360328

Currently, the `solrctl` command runs on the host system. The host command is required,
so solr picks up the configuration on start-up (e.g. post-start).

The host command requires `yq` to be installed.

## How This PR Solves The Issue

To reduce the host dependencies (yq) and have a consistent environment `ddev solrctl-worker` was added
that will be used by `ddev solrctl` to create and delete solr cores.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-typo3-solr/tarball/task/run-in-container
ddev restart
```

## Automated Testing Overview

Does not require additional tests

## Release/Deployment Notes

- 