### PR TITLE
[BUGFIX] Hardcode internal solr port

### DIFF
--- a/commands/web/solrctl-worker
+++ b/commands/web/solrctl-worker
@@ -8,8 +8,7 @@
 set -euo pipefail
 
 SOLR_HOST="typo3-solr"
-SOLR_PORT="${SOLR_PORT:-8983}"
-SOLR_API="http://${SOLR_HOST}:${SOLR_PORT}/solr"
+SOLR_API="http://${SOLR_HOST}:8983/solr"
 SOLR_DATA="/mnt/typo3-solr/data"
 
 resolve_path() {


### PR DESCRIPTION
## The Issue

- #28 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Hardcode the internal solr port. This seems to be fine, because HTTP_EXPOSE and HTTPS_EXPOSE
map to 8983 anyway

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
