### PR TITLE
chore: remove obsolete wait logic

### DIFF
--- a/commands/host/solrctl
+++ b/commands/host/solrctl
@@ -23,36 +23,23 @@ apply)
     IS_SOLR_CLOUD=$(ddev solrctl-worker is-solrcloud)
 
     if [ "$IS_SOLR_CLOUD" = "true" ]; then
-        echo "🌥️  SolrCloud mode detected — uploading configsets to ZooKeeper"
-
-        if ! ddev solrctl-worker typo3lib-registered 2>/dev/null; then
-            echo "📦 Registering typo3lib sharedLib..."
+        echo "🌥️  SolrCloud mode detected — uploading configsets with ZooKeeper"
+        if ! ddev solrctl-worker typo3lib-registered >/dev/null 2>&1; then
             ddev exec -s typo3-solr -u root chmod -R 777 /var/solr/
             ddev solrctl-worker register-typo3lib "$YAML_FILE"
             ddev exec -s typo3-solr -u root chown -R solr:solr /var/solr/
-            echo "⬆️  Uploading solr.xml to ZooKeeper..."
-            ddev solr-zk cp file:///var/solr/data/solr.xml zk:/solr.xml -z localhost:9983
-            echo "🔄 Restarting Solr to load typo3lib..."
-            ddev utility rebuild -s typo3-solr --cache
-            echo "⏳ Waiting for SolrCloud to be ready..."
-            attempts=0
-            until ddev solrctl-worker is-solrcloud 2>/dev/null | grep -q "^true$"; do
-                attempts=$((attempts + 1))
-                if [ "$attempts" -ge 30 ]; then
-                    echo "❌ SolrCloud not ready after 90s"
-                    exit 1
-                fi
-                sleep 3
-            done
-            echo "✅ SolrCloud ready with typo3lib"
+            ddev utility rebuild -s typo3-solr --cache 1>/dev/null
         fi
-
+        echo "⬆️  Uploading solr.xml to ZooKeeper..."
+        ddev solr-zk cp file:///var/solr/data/solr.xml zk:/solr.xml -z localhost:9983
         ddev solrctl-worker upload-configsets "$YAML_FILE"
-        echo "🔨 Creating collections"
         ddev solrctl-worker create-collections "$YAML_FILE"
     else
         echo "🖥️  Standalone mode — copying configsets to volume"
         ddev exec -s typo3-solr -u root chmod -R 777 /var/solr/
+        if ! ddev solrctl-worker typo3lib-registered >/dev/null 2>&1; then
+            ddev solrctl-worker register-typo3lib "$YAML_FILE"
+        fi
         ddev solrctl-worker copy-config "$YAML_FILE"
         ddev exec -s typo3-solr -u root chown -R solr:solr /var/solr/
         ddev utility rebuild -s typo3-solr --cache 1>/dev/null

--- a/commands/web/solrctl-worker
+++ b/commands/web/solrctl-worker
@@ -30,7 +30,7 @@ cmd_is_solrcloud() {
 
 cmd_typo3lib_registered() {
     if [ -d "${SOLR_DATA}/typo3lib" ]; then
-        echo "✅ typo3lib registered"
+        echo "ℹ️ typo3lib already registered"
     else
         echo "❌ typo3lib not registered"
         return 1
@@ -86,7 +86,7 @@ seed_managed_resources_for_collection() {
                     -H "Content-Type: application/json" -d "$words_json")
                 [ "$(solr_status "$response")" = "0" ] \
                     && echo "  📚 Seeded ${word_count} stopwords (${lang_code})" \
-                    || echo "  ⚠️  Stopword seed failed: $(solr_error "$response")"
+                    || echo "  ❌  Stopword seed failed: $(solr_error "$response")"
             fi
         else
             echo "  ℹ️  Stopwords already populated (${current_count} words)"
@@ -110,7 +110,7 @@ seed_managed_resources_for_collection() {
                     -H "Content-Type: application/json" -d "$map_json")
                 [ "$(solr_status "$response")" = "0" ] \
                     && echo "  📚 Seeded ${entry_count} synonym entries (${lang_code})" \
-                    || echo "  ⚠️  Synonym seed failed: $(solr_error "$response")"
+                    || echo "  ❌  Synonym seed failed: $(solr_error "$response")"
             fi
         else
             echo "  ℹ️  Synonyms already populated (${current_count} entries)"
@@ -266,7 +266,7 @@ cmd_wipe_cloud() {
     fi
 }
 
-# Copy solr.xml and typo3lib to SOLR_DATA (shared volume) for SolrCloud sharedLib loading.
+# Copy solr.xml and typo3lib to SOLR_DATA (shared volume)
 cmd_register_typo3lib() {
     local yaml_file
     yaml_file=$(resolve_path "$1")
@@ -290,8 +290,6 @@ cmd_copy_config() {
     yaml_file=$(resolve_path "$1")
 
     [ ! -f "$yaml_file" ] && { echo "Add-on config file $yaml_file does not exist."; exit 1; }
-
-    cmd_register_typo3lib "$yaml_file"
 
     local configset_count
     configset_count=$(yq eval '.configsets | length' "$yaml_file")

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -124,7 +124,9 @@ health_checks_solrcloud() {
   assert_success
   assert_output --partial "Apply config tests/testdata/config.yaml"
   assert_output --partial "SolrCloud mode detected"
-  assert_output --partial "SolrCloud ready with typo3lib"
+  assert_output --partial "Copying solr.xml to Solr data dir"
+  assert_output --partial "Copying typo3lib to Solr data dir"
+  assert_output --partial "Uploading solr.xml to ZooKeeper"
   assert_output --partial "Configset 'example_configset_english' uploaded"
   assert_output --partial "Configset 'example_configset_german' uploaded"
   assert_output --partial "Collection 'core_en' created"


### PR DESCRIPTION
Remove unnecessary wait for restart. It's causing only problems. `ddev utility rebuild -s typo3-solr --cache` automatically prevents the script from continuing.

Remove some echo to reduce noise when `ddev solrctl apply` is executed.